### PR TITLE
SanLite 1.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<checkstyle.skip>true</checkstyle.skip>
 
 		<rs.version>181</rs.version>
-		<sanlite.version>1.3.0</sanlite.version>
+		<sanlite.version>1.3.1</sanlite.version>
 	</properties>
 
 	<licenses>

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletConfig.java
@@ -184,7 +184,7 @@ public interface GauntletConfig extends Config
 	)
 	default Color getGrymRootColor()
 	{
-		return new Color(210, 23, 23);
+		return new Color(160, 10, 10);
 	}
 
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletOverlay.java
@@ -1,7 +1,7 @@
 package net.runelite.client.plugins.gauntlet;
 
-import net.runelite.api.*;
 import net.runelite.api.Point;
+import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.client.game.SkillIconManager;
 import net.runelite.client.ui.overlay.Overlay;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletPlugin.java
@@ -119,7 +119,7 @@ public class GauntletPlugin extends Plugin
 		if (!config.showPaddlefishSpots())
 		{
 			resourceSpots.removeIf(spot -> spot.getId() == GAUNTLET_FISHING_SPOT ||
-							spot.getId() == CORRUPTED_GAUNTLET_FISHING_SPOT);
+					spot.getId() == CORRUPTED_GAUNTLET_FISHING_SPOT);
 		}
 
 		if (!config.showCrystalDeposits())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletResourceSpotMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/gauntlet/GauntletResourceSpotMinimapOverlay.java
@@ -1,6 +1,5 @@
 package net.runelite.client.plugins.gauntlet;
 
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.GameObject;
 import net.runelite.api.Point;
 import net.runelite.client.ui.overlay.Overlay;
@@ -11,7 +10,6 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 import javax.inject.Inject;
 import java.awt.*;
 
-@Slf4j
 public class GauntletResourceSpotMinimapOverlay extends Overlay
 {
 	private final GauntletPlugin plugin;
@@ -50,7 +48,7 @@ public class GauntletResourceSpotMinimapOverlay extends Overlay
 		Point minimapLocation = gameObject.getMinimapLocation();
 		if (minimapLocation != null)
 		{
-			OverlayUtil.renderMinimapLocation(graphics, minimapLocation, color.darker());
+			OverlayUtil.renderMinimapLocation(graphics, minimapLocation, color);
 		}
 	}
 }


### PR DESCRIPTION
Small changes to The Gauntlet plugin:
- Remove darker color shader for resource spot minimap dots
- Changed color of Grym root so it does not share a color with dropped items