### PR TITLE
Fix Entity Hider plugin & click limit increased

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -1515,20 +1515,6 @@ public interface Client extends GameShell
 	void setNPCsHidden(boolean state);
 
 	/**
-	 * Sets which NPCs are hidden
-	 *
-	 * @param names the names of the npcs
-	 */
-	void setNPCsNames(List<String> names);
-
-	/**
-	 * Sets which NPCs are hidden on death
-	 *
-	 * @param names the names of the npcs
-	 */
-	void setNPCsHiddenOnDeath(List<String> names);
-
-	/**
 	 * Sets whether 2D sprites (ie. overhead prayers) related to
 	 * the NPCs are hidden.
 	 *
@@ -1549,13 +1535,6 @@ public interface Client extends GameShell
 	 * @param state new projectile hidden state
 	 */
 	void setProjectilesHidden(boolean state);
-
-	/**
-	 * Sets whether dead NPCs are hidden.
-	 *
-	 * @param state new NPC hidden state
-	 */
-	void setDeadNPCsHidden(boolean state);
 
 	/**
 	 * Gets an array of tile collision data.

--- a/runelite-mixins/src/main/java/net/runelite/mixins/ClickboxMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/ClickboxMixin.java
@@ -20,7 +20,7 @@ public abstract class ClickboxMixin implements RSClient
 	private static final int MAX_ENTITES_AT_MOUSE = 1000;
 	private static final int CLICKBOX_CLOSE = 50;
 	private static final int CLICKBOX_FAR = 10000;
-	private static final int OBJECT_INTERACTION_FAR = 100; // Max distance, in tiles, from camera
+	private static final int OBJECT_INTERACTION_FAR = 200; // Max distance, in tiles, from camera
 
 	@Inject
 	private static final int[] rl$modelViewportXs = new int[4700];

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
@@ -24,7 +24,6 @@
  */
 package net.runelite.mixins;
 
-import java.util.List;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
 import net.runelite.rs.api.RSClient;
@@ -64,15 +63,6 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 
 	@Inject
 	public static boolean hideProjectiles;
-
-	@Inject
-	public static boolean hideDeadNPCs;
-
-	@Inject
-	public static List<String> hideNPCsNames;
-
-	@Inject
-	public static List<String> hideNPCsOnDeath;
 
 	@Inject
 	@Override
@@ -139,20 +129,6 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 
 	@Inject
 	@Override
-	public void setNPCsNames(List<String> NPCs)
-	{
-		hideNPCsNames = NPCs;
-	}
-
-	@Inject
-	@Override
-	public void setNPCsHiddenOnDeath(List<String> NPCs)
-	{
-		hideNPCsOnDeath = NPCs;
-	}
-
-	@Inject
-	@Override
 	public void setAttackersHidden(boolean state)
 	{
 		hideAttackers = state;
@@ -163,12 +139,5 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	public void setProjectilesHidden(boolean state)
 	{
 		hideProjectiles = state;
-	}
-
-	@Inject
-	@Override
-	public void setDeadNPCsHidden(boolean state)
-	{
-		hideDeadNPCs = state;
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
@@ -24,9 +24,6 @@
  */
 package net.runelite.mixins;
 
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import net.runelite.api.mixins.Copy;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
@@ -43,12 +40,6 @@ import net.runelite.rs.api.RSScene;
 @Mixin(RSScene.class)
 public abstract class EntityHiderMixin implements RSScene
 {
-	@Inject
-	private static final Pattern WILDCARD_PATTERN = Pattern.compile("(?i)[^*]+|(\\*)");
-
-	@Inject
-	private static final Pattern TAG_REGEXP = Pattern.compile("<[^>]*>");
-
 	@Shadow("client")
 	private static RSClient client;
 
@@ -76,12 +67,6 @@ public abstract class EntityHiderMixin implements RSScene
 	@Shadow("hideNPCs")
 	private static boolean hideNPCs;
 
-	@Shadow("hideNPCsNames")
-	private static List<String> hideNPCsNames;
-
-	@Shadow("hideNPCsOnDeath")
-	private static List<String> hideNPCsOnDeath;
-
 	@Shadow("hideNPCs2D")
 	private static boolean hideNPCs2D;
 
@@ -90,9 +75,6 @@ public abstract class EntityHiderMixin implements RSScene
 
 	@Shadow("hideProjectiles")
 	private static boolean hideProjectiles;
-
-	@Shadow("hideDeadNPCs")
-	private static boolean hideDeadNPCs;
 
 	@Copy("newGameObject")
 	abstract boolean addEntityMarker(int var1, int var2, int var3, int var4, int var5, int x, int y, int var8, RSEntity entity, int var10, boolean var11, long var12, int var13);
@@ -178,33 +160,6 @@ public abstract class EntityHiderMixin implements RSScene
 				}
 			}
 
-			if (hideDeadNPCs && npc.getHealthRatio() == 0)
-			{
-				return false;
-			}
-
-			for (String name : hideNPCsNames)
-			{
-				if (name != null && !name.equals(""))
-				{
-					if (npc.getName() != null && matches(name, npc.getName()))
-					{
-						return false;
-					}
-				}
-			}
-
-			for (String name : hideNPCsOnDeath)
-			{
-				if (name != null && !name.equals(""))
-				{
-					if (npc.getName() != null && matches(name, npc.getName()) && npc.getHealthRatio() == 0)
-					{
-						return false;
-					}
-				}
-			}
-
 			return drawingUI ? !hideNPCs2D : !hideNPCs;
 		}
 		else if (entity instanceof RSProjectile)
@@ -213,35 +168,5 @@ public abstract class EntityHiderMixin implements RSScene
 		}
 
 		return true;
-	}
-
-	@Inject
-	static private boolean matches(String pattern, String text)
-	{
-		String standardized = TAG_REGEXP.matcher(text)
-			.replaceAll("")
-			.replace('\u00A0', ' ')
-			.toLowerCase();
-
-		final Matcher matcher = WILDCARD_PATTERN.matcher(pattern.toLowerCase());
-		final StringBuffer buffer = new StringBuffer();
-
-		buffer.append("(?i)");
-		while (matcher.find())
-		{
-			if (matcher.group(1) != null)
-			{
-				matcher.appendReplacement(buffer, ".*");
-			}
-			else
-			{
-				matcher.appendReplacement(buffer, "\\\\Q" + matcher.group(0) + "\\\\E");
-			}
-		}
-
-		matcher.appendTail(buffer);
-		final String replaced = buffer.toString();
-
-		return standardized.matches(replaced);
 	}
 }


### PR DESCRIPTION
- Fixed the Entity Hider plugin causing a game crash when turned on. 
- Increased click limit from 100 to 200 tiles.