### PR TITLE
SanLite 1.11.2 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<checkstyle.skip>true</checkstyle.skip>
 
 		<rs.version>188</rs.version>
-		<sanlite.version>1.11.1</sanlite.version>
+		<sanlite.version>1.11.2</sanlite.version>
 	</properties>
 
 	<licenses>

--- a/runelite-api/src/main/java/net/runelite/api/widgets/Widget.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/Widget.java
@@ -925,4 +925,8 @@ public interface Widget
 	 * @param args A ScriptID, then the args for the script
 	 */
 	void setOnReleaseListener(Object ...args);
+
+	boolean isWidgetItemDragged(int index);
+
+	Point getWidgetItemDragOffsets();
 }

--- a/runelite-api/src/main/java/net/runelite/api/widgets/WidgetItem.java
+++ b/runelite-api/src/main/java/net/runelite/api/widgets/WidgetItem.java
@@ -63,6 +63,10 @@ public class WidgetItem
 	 * The widget which contains this item.
 	 */
 	private final Widget widget;
+	/**
+	 * Whether or not this widget item is being dragged.
+	 */
+	private final boolean dragging;
 
 	/**
 	 * Gets the upper-left coordinate of where the widget is being drawn

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -1394,7 +1394,7 @@ public abstract class RSClientMixin implements RSClient
 			{
 				if (renderX >= minX && renderX <= maxX && renderY >= minY && renderY <= maxY)
 				{
-					WidgetItem widgetItem = new WidgetItem(widget.getItemId(), widget.getItemQuantity(), -1, widget.getBounds(), widget);
+					WidgetItem widgetItem = new WidgetItem(widget.getItemId(), widget.getItemQuantity(), -1, widget.getBounds(), widget, false);
 					callbacks.drawItem(widget.getItemId(), widgetItem);
 				}
 			}
@@ -1633,7 +1633,7 @@ public abstract class RSClientMixin implements RSClient
 	{
 		if (volume > 0 && client.getMusicVolume() <= 0 && client.getCurrentTrackGroupId() != -1)
 		{
-			client.playMusicTrack(client.getMusicTracks(), String.valueOf(client.getCurrentTrackGroupId()), "0", volume, false);
+			client.playMusicTrack(1000, client.getMusicTracks(), client.getCurrentTrackGroupId(), 0, volume, false);
 		}
 
 		client.setClientMusicVolume(volume);

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSWidgetMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSWidgetMixin.java
@@ -285,8 +285,19 @@ public abstract class RSWidgetMixin implements RSWidget
 		int itemX = rl$x + ((ITEM_SLOT_SIZE + xPitch) * col);
 		int itemY = rl$y + ((ITEM_SLOT_SIZE + yPitch) * row);
 
-		Rectangle bounds = new Rectangle(itemX, itemY, ITEM_SLOT_SIZE, ITEM_SLOT_SIZE);
-		return new WidgetItem(itemId - 1, itemQuantity, index, bounds, this);
+		boolean isDragged = isWidgetItemDragged(index);
+		int dragOffsetX = 0;
+		int dragOffsetY = 0;
+
+		if (isDragged)
+		{
+			Point p = getWidgetItemDragOffsets();
+			dragOffsetX = p.getX();
+			dragOffsetY = p.getY();
+		}
+
+		Rectangle bounds = new Rectangle(itemX + dragOffsetX, itemY + dragOffsetY, ITEM_SLOT_SIZE, ITEM_SLOT_SIZE);
+		return new WidgetItem(itemId - 1, itemQuantity, index, bounds, this, isDragged);
 	}
 
 	@Inject
@@ -576,5 +587,32 @@ public abstract class RSWidgetMixin implements RSWidget
 			frame = frame | getModelFrameCycle() << 16 | Integer.MIN_VALUE;
 		}
 		return rs$getModel(sequence, frame, alternate, playerComposition);
+	}
+
+	@Inject
+	@Override
+	public boolean isWidgetItemDragged(int index)
+	{
+		return client.getIf1DraggedWidget() == this && client.getItemPressedDuration() >= 5 &&
+			client.getIf1DraggedItemIndex() == index;
+	}
+
+	@Inject
+	public Point getWidgetItemDragOffsets()
+	{
+		int dragOffsetX = client.getMouseX() - client.getDraggedWidgetX();
+		int dragOffsetY = client.getMouseY() - client.getDraggedWidgetY();
+
+		if (dragOffsetX < 5 && dragOffsetX > -5)
+		{
+			dragOffsetX = 0;
+		}
+
+		if (dragOffsetY < 5 && dragOffsetY > -5)
+		{
+			dragOffsetY = 0;
+		}
+
+		return new Point(dragOffsetX, dragOffsetY);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/SoundEffectMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/SoundEffectMixin.java
@@ -103,17 +103,17 @@ public abstract class SoundEffectMixin implements RSClient
 	}
 
 	@Copy("updateActorSequence")
-	public static void rs$updateActorSequence(RSActor actor)
+	public static void rs$updateActorSequence(RSActor actor, int length)
 	{
 		throw new RuntimeException();
 	}
 
 	@Replace("updateActorSequence")
-	public static void rl$updateActorSequence(RSActor actor)
+	public static void rl$updateActorSequence(RSActor actor, int length)
 	{
 		lastSoundEffectSourceActor = actor;
 
-		rs$updateActorSequence(actor);
+		rs$updateActorSequence(actor, length);
 
 		lastSoundEffectSourceActor = null;
 	}

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -1043,7 +1043,7 @@ public interface RSClient extends RSGameShell, Client
 	void setViewportWalking(boolean viewportWalking);
 
 	@Import("playMusicTrack")
-	void playMusicTrack(RSAbstractArchive var0, String var1, String var2, int var3, boolean var4);
+	void playMusicTrack(int var0, RSAbstractArchive var1, int var2, int var3, int var4, boolean var5);
 
 	@Import("midiPcmStream")
 	RSMidiPcmStream getMidiPcmStream();
@@ -1097,4 +1097,9 @@ public interface RSClient extends RSGameShell, Client
 	@Override
 	void scaleSprite(int[] canvas, int[] pixels, int color, int pixelX, int pixelY, int canvasIdx, int canvasOffset, int newWidth, int newHeight, int pixelWidth, int pixelHeight, int oldWidth);
 
+	@Import("draggedWidgetX")
+	int getDraggedWidgetX();
+
+	@Import("draggedWidgetY")
+	int getDraggedWidgetY();
 }

--- a/runescape-client/src/main/java/Buffer.java
+++ b/runescape-client/src/main/java/Buffer.java
@@ -895,8 +895,8 @@ public class Buffer extends Node {
 		signature = "(II)V",
 		garbageValue = "1143249456"
 	)
-	@Export("writeIntME")
-	public void writeIntME(int var1) {
+	@Export("writeShortLE")
+	public void writeShortLE(int var1) {
 		this.array[++this.offset - 1] = (byte)var1;
 		this.array[++this.offset - 1] = (byte)(var1 >> 8);
 	}
@@ -916,7 +916,8 @@ public class Buffer extends Node {
 		signature = "(IB)V",
 		garbageValue = "73"
 	)
-	public void method5613(int var1) {
+	@Export("writeIntME")
+	public void writeIntME(int var1) {
 		this.array[++this.offset - 1] = (byte)(var1 + 128);
 		this.array[++this.offset - 1] = (byte)(var1 >> 8);
 	}

--- a/runescape-client/src/main/java/BufferedSink.java
+++ b/runescape-client/src/main/java/BufferedSink.java
@@ -286,7 +286,7 @@ public class BufferedSink implements Runnable {
 			class197.field2414 = 1;
 			UserComparator5.musicTrackArchive = null;
 		} else if (var0 != -1 && var0 != Client.currentTrackGroupId && Client.musicVolume != 0 && !Client.field881) {
-			TaskHandler.method3554(2, MouseHandler.archive6, var0, 0, Client.musicVolume, false);
+			TaskHandler.playMusicTrack(2, MouseHandler.archive6, var0, 0, Client.musicVolume, false);
 		}
 
 		Client.currentTrackGroupId = var0;

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -1064,12 +1064,14 @@ public final class Client extends GameShell implements Usernamed {
 	@ObfuscatedGetter(
 		intValue = -509412397
 	)
-	static int field754;
+	@Export("draggedWidgetX")
+	static int draggedWidgetX;
 	@ObfuscatedName("jn")
 	@ObfuscatedGetter(
 		intValue = 24720215
 	)
-	static int field755;
+	@Export("draggedWidgetY")
+	static int draggedWidgetY;
 	@ObfuscatedName("jt")
 	@ObfuscatedGetter(
 		intValue = -200424637
@@ -1393,8 +1395,8 @@ public final class Client extends GameShell implements Usernamed {
 		field751 = 0;
 		field752 = 0;
 		dragItemSlotSource = 0;
-		field754 = 0;
-		field755 = 0;
+		draggedWidgetX = 0;
+		draggedWidgetY = 0;
 		dragItemSlotDestination = 0;
 		field757 = false;
 		itemDragDuration = 0;
@@ -3351,7 +3353,7 @@ public final class Client extends GameShell implements Usernamed {
 					field730 = false;
 					var14 = TilePaint.getPacketBufferNode(ClientPacket.field2208, packetWriter.isaacCipher);
 					var14.packetBuffer.method5787(camAngleY);
-					var14.packetBuffer.writeIntME(camAngleX);
+					var14.packetBuffer.writeShortLE(camAngleX);
 					packetWriter.addNode(var14);
 				}
 
@@ -3626,15 +3628,15 @@ public final class Client extends GameShell implements Usernamed {
 																			packetWriter.addNode(var43);
 																		}
 																	} else if (this.shouldLeftClickOpenMenu()) {
-																		this.openMenu(field754, field755);
+																		this.openMenu(draggedWidgetX, draggedWidgetY);
 																	} else if (menuOptionsCount > 0) {
-																		GrandExchangeOfferTotalQuantityComparator.method105(field754, field755);
+																		GrandExchangeOfferTotalQuantityComparator.method105(draggedWidgetX, draggedWidgetY);
 																	}
 
 																	field751 = 10;
 																	MouseHandler.MouseHandler_lastButton = 0;
 																	class185.dragInventoryWidget = null;
-																} else if (itemDragDuration >= 5 && (MouseHandler.MouseHandler_x > field754 + 5 || MouseHandler.MouseHandler_x < field754 - 5 || MouseHandler.MouseHandler_y > field755 + 5 || MouseHandler.MouseHandler_y < field755 - 5)) {
+																} else if (itemDragDuration >= 5 && (MouseHandler.MouseHandler_x > draggedWidgetX + 5 || MouseHandler.MouseHandler_x < draggedWidgetX - 5 || MouseHandler.MouseHandler_y > draggedWidgetY + 5 || MouseHandler.MouseHandler_y < draggedWidgetY - 5)) {
 																	field757 = true;
 																}
 															}
@@ -3642,7 +3644,7 @@ public final class Client extends GameShell implements Usernamed {
 															if (Scene.method3321()) {
 																var3 = Scene.Scene_selectedX;
 																var4 = Scene.Scene_selectedY;
-																var43 = TilePaint.getPacketBufferNode(ClientPacket.ClientPacket_field2180, packetWriter.isaacCipher);
+																var43 = TilePaint.getPacketBufferNode(ClientPacket.SEND_CLICK_PACKET, packetWriter.isaacCipher);
 																var43.packetBuffer.writeByte(5);
 																var43.packetBuffer.writeShort(Language.baseY * 64 + var4);
 																var43.packetBuffer.method5787(Messages.baseX * 64 + var3);
@@ -5700,7 +5702,7 @@ public final class Client extends GameShell implements Usernamed {
 				}
 
 				if (class185.dragInventoryWidget != null && !field757 && menuOptionsCount > 0 && !this.shouldLeftClickOpenMenu()) {
-					GrandExchangeOfferTotalQuantityComparator.method105(field754, field755);
+					GrandExchangeOfferTotalQuantityComparator.method105(draggedWidgetX, draggedWidgetY);
 				}
 
 				field757 = false;
@@ -5711,8 +5713,8 @@ public final class Client extends GameShell implements Usernamed {
 
 				class185.dragInventoryWidget = Varps.getWidget(var6);
 				dragItemSlotSource = var5;
-				field754 = MouseHandler.MouseHandler_lastPressedX;
-				field755 = MouseHandler.MouseHandler_lastPressedY;
+				draggedWidgetX = MouseHandler.MouseHandler_lastPressedX;
+				draggedWidgetY = MouseHandler.MouseHandler_lastPressedY;
 				if (var2 >= 0) {
 					WorldMapRegion.tempMenuAction = new MenuAction();
 					WorldMapRegion.tempMenuAction.param0 = menuArguments1[var2];
@@ -5878,12 +5880,12 @@ public final class Client extends GameShell implements Usernamed {
 
 					if (draggedOnWidget != null && ItemContainer.method1184(clickedWidget) != null) {
 						PacketBufferNode var9 = TilePaint.getPacketBufferNode(ClientPacket.field2242, packetWriter.isaacCipher);
-						var9.packetBuffer.method5613(draggedOnWidget.childIndex);
+						var9.packetBuffer.writeIntME(draggedOnWidget.childIndex);
 						var9.packetBuffer.method5787(clickedWidget.itemId);
 						var9.packetBuffer.method5622(clickedWidget.id);
 						var9.packetBuffer.method5622(draggedOnWidget.id);
-						var9.packetBuffer.writeIntME(draggedOnWidget.itemId);
-						var9.packetBuffer.writeIntME(clickedWidget.childIndex);
+						var9.packetBuffer.writeShortLE(draggedOnWidget.itemId);
+						var9.packetBuffer.writeShortLE(clickedWidget.childIndex);
 						packetWriter.addNode(var9);
 					}
 				} else if (this.shouldLeftClickOpenMenu()) {

--- a/runescape-client/src/main/java/ClientPacket.java
+++ b/runescape-client/src/main/java/ClientPacket.java
@@ -221,8 +221,8 @@ public class ClientPacket implements class181 {
 	@ObfuscatedSignature(
 		signature = "Lgi;"
 	)
-	@Export("ClientPacket_field2180")
-	public static final ClientPacket ClientPacket_field2180;
+	@Export("ClientPacket_SEND_CLICK_PACKET")
+	public static final ClientPacket SEND_CLICK_PACKET;
 	@ObfuscatedName("am")
 	@ObfuscatedSignature(
 		signature = "Lgi;"
@@ -569,7 +569,7 @@ public class ClientPacket implements class181 {
 		field2242 = new ClientPacket(39, 16);
 		field2243 = new ClientPacket(40, 3);
 		field2244 = new ClientPacket(41, 7);
-		ClientPacket_field2180 = new ClientPacket(42, -1);
+		SEND_CLICK_PACKET = new ClientPacket(42, -1);
 		field2245 = new ClientPacket(43, 7);
 		field2247 = new ClientPacket(44, 0);
 		field2241 = new ClientPacket(45, -2);

--- a/runescape-client/src/main/java/Entity.java
+++ b/runescape-client/src/main/java/Entity.java
@@ -62,7 +62,7 @@ public abstract class Entity extends DualNode {
 		for (int var2 = 0; var2 < var0; ++var2) {
 			Player var3 = Client.players[var1[var2]];
 			if (var3 != null) {
-				ScriptFrame.method1161(var3, 1);
+				ScriptFrame.updateActorSequence(var3, 1);
 			}
 		}
 

--- a/runescape-client/src/main/java/FloorOverlayDefinition.java
+++ b/runescape-client/src/main/java/FloorOverlayDefinition.java
@@ -452,8 +452,8 @@ public class FloorOverlayDefinition extends DualNode {
 
 													if (var35 != null) {
 														if (var10 == class185.dragInventoryWidget && var30 == Client.dragItemSlotSource) {
-															var24 = MouseHandler.MouseHandler_x - Client.field754;
-															var25 = MouseHandler.MouseHandler_y - Client.field755;
+															var24 = MouseHandler.MouseHandler_x - Client.draggedWidgetX;
+															var25 = MouseHandler.MouseHandler_y - Client.draggedWidgetY;
 															if (var24 < 5 && var24 > -5) {
 																var24 = 0;
 															}
@@ -482,7 +482,7 @@ public class FloorOverlayDefinition extends DualNode {
 																	}
 
 																	var28.scrollY -= var29;
-																	Client.field755 += var29;
+																	Client.draggedWidgetY += var29;
 																	NPCDefinition.invalidateWidget(var28);
 																}
 
@@ -497,7 +497,7 @@ public class FloorOverlayDefinition extends DualNode {
 																	}
 
 																	var28.scrollY += var29;
-																	Client.field755 -= var29;
+																	Client.draggedWidgetY -= var29;
 																	NPCDefinition.invalidateWidget(var28);
 																}
 															}

--- a/runescape-client/src/main/java/GrandExchangeEvents.java
+++ b/runescape-client/src/main/java/GrandExchangeEvents.java
@@ -92,7 +92,7 @@ public class GrandExchangeEvents {
 				WorldMapSection2.clientPreferences.titleMusicDisabled = !WorldMapSection2.clientPreferences.titleMusicDisabled;
 				WorldMapData_1.savePreferences();
 				if (!WorldMapSection2.clientPreferences.titleMusicDisabled) {
-					class162.playMusicTrack(MouseHandler.archive6, "scape main", "", 255, false);
+					class162.method3523(MouseHandler.archive6, "scape main", "", 255, false);
 				} else {
 					class197.midiPcmStream.clear();
 					class197.field2414 = 1;

--- a/runescape-client/src/main/java/ScriptEvent.java
+++ b/runescape-client/src/main/java/ScriptEvent.java
@@ -130,7 +130,7 @@ public class ScriptEvent extends Node {
 				} else if (var0 == 4) {
 					var8 = TilePaint.getPacketBufferNode(ClientPacket.field2216, Client.packetWriter.isaacCipher);
 					var8.packetBuffer.writeByte(0);
-					var8.packetBuffer.writeIntME(var3[var6]);
+					var8.packetBuffer.writeShortLE(var3[var6]);
 					Client.packetWriter.addNode(var8);
 				} else if (var0 == 6) {
 					var8 = TilePaint.getPacketBufferNode(ClientPacket.field2221, Client.packetWriter.isaacCipher);

--- a/runescape-client/src/main/java/ScriptFrame.java
+++ b/runescape-client/src/main/java/ScriptFrame.java
@@ -112,13 +112,14 @@ public class ScriptFrame {
 		signature = "(Lbx;II)V",
 		garbageValue = "1584696624"
 	)
-	static final void method1161(Actor var0, int var1) {
+	@Export("updateActorSequence")
+	static final void updateActorSequence(Actor var0, int var1) {
 		if (var0.field985 >= Client.cycle) {
 			class185.method3685(var0);
 		} else if (var0.field986 >= Client.cycle) {
 			GrandExchangeEvent.method88(var0);
 		} else {
-			WorldMapRegion.updateActorSequence(var0);
+			WorldMapRegion.method565(var0);
 		}
 
 		if (var0.x < 128 || var0.y < 128 || var0.x >= 13184 || var0.y >= 13184) {

--- a/runescape-client/src/main/java/TaskHandler.java
+++ b/runescape-client/src/main/java/TaskHandler.java
@@ -186,7 +186,8 @@ public class TaskHandler implements Runnable {
 		signature = "(ILii;IIIZI)V",
 		garbageValue = "869410445"
 	)
-	public static void method3554(int var0, AbstractArchive var1, int var2, int var3, int var4, boolean var5) {
+	@Export("playMusicTrack")
+	public static void playMusicTrack(int var0, AbstractArchive var1, int var2, int var3, int var4, boolean var5) {
 		class197.field2414 = 1;
 		UserComparator5.musicTrackArchive = var1;
 		class197.musicTrackGroupId = var2;

--- a/runescape-client/src/main/java/UserComparator10.java
+++ b/runescape-client/src/main/java/UserComparator10.java
@@ -78,12 +78,12 @@ public class UserComparator10 extends AbstractUserComparator {
 			Client.destinationY = var1;
 			var8 = TilePaint.getPacketBufferNode(ClientPacket.field2267, Client.packetWriter.isaacCipher);
 			var8.packetBuffer.method5787(class65.selectedItemSlot);
-			var8.packetBuffer.writeIntME(MusicPatch.selectedItemId);
-			var8.packetBuffer.method5613(var3);
+			var8.packetBuffer.writeShortLE(MusicPatch.selectedItemId);
+			var8.packetBuffer.writeIntME(var3);
 			var8.packetBuffer.method5604(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
-			var8.packetBuffer.method5613(Language.baseY * 64 + var1);
+			var8.packetBuffer.writeIntME(Language.baseY * 64 + var1);
 			var8.packetBuffer.method5623(FriendSystem.selectedItemWidget);
-			var8.packetBuffer.writeIntME(Messages.baseX * 64 + var0);
+			var8.packetBuffer.writeShortLE(Messages.baseX * 64 + var0);
 			Client.packetWriter.addNode(var8);
 		} else if (var2 == 2) {
 			Client.mouseCrossX = var6;
@@ -98,7 +98,7 @@ public class UserComparator10 extends AbstractUserComparator {
 			var8.packetBuffer.writeShort(Client.selectedSpellChildIndex);
 			var8.packetBuffer.method5604(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
 			var8.packetBuffer.writeShort(Language.baseY * 64 + var1);
-			var8.packetBuffer.writeIntME(Messages.baseX * 64 + var0);
+			var8.packetBuffer.writeShortLE(Messages.baseX * 64 + var0);
 			Client.packetWriter.addNode(var8);
 		} else if (var2 == 3) {
 			Client.mouseCrossX = var6;
@@ -109,8 +109,8 @@ public class UserComparator10 extends AbstractUserComparator {
 			Client.destinationY = var1;
 			var8 = TilePaint.getPacketBufferNode(ClientPacket.field2236, Client.packetWriter.isaacCipher);
 			var8.packetBuffer.method5602(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
-			var8.packetBuffer.writeIntME(Language.baseY * 64 + var1);
-			var8.packetBuffer.writeIntME(var3);
+			var8.packetBuffer.writeShortLE(Language.baseY * 64 + var1);
+			var8.packetBuffer.writeShortLE(var3);
 			var8.packetBuffer.method5787(Messages.baseX * 64 + var0);
 			Client.packetWriter.addNode(var8);
 		} else if (var2 == 4) {
@@ -134,10 +134,10 @@ public class UserComparator10 extends AbstractUserComparator {
 			Client.destinationX = var0;
 			Client.destinationY = var1;
 			var8 = TilePaint.getPacketBufferNode(ClientPacket.field2299, Client.packetWriter.isaacCipher);
-			var8.packetBuffer.writeIntME(var3);
+			var8.packetBuffer.writeShortLE(var3);
 			var8.packetBuffer.method5602(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
 			var8.packetBuffer.method5787(Messages.baseX * 64 + var0);
-			var8.packetBuffer.writeIntME(Language.baseY * 64 + var1);
+			var8.packetBuffer.writeShortLE(Language.baseY * 64 + var1);
 			Client.packetWriter.addNode(var8);
 		} else if (var2 == 6) {
 			Client.mouseCrossX = var6;
@@ -150,7 +150,7 @@ public class UserComparator10 extends AbstractUserComparator {
 			var8.packetBuffer.method5787(Messages.baseX * 64 + var0);
 			var8.packetBuffer.method5787(Language.baseY * 64 + var1);
 			var8.packetBuffer.method5603(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
-			var8.packetBuffer.writeIntME(var3);
+			var8.packetBuffer.writeShortLE(var3);
 			Client.packetWriter.addNode(var8);
 		} else {
 			PacketBufferNode var9;
@@ -168,8 +168,8 @@ public class UserComparator10 extends AbstractUserComparator {
 					var9.packetBuffer.method5602(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
 					var9.packetBuffer.method5787(var3);
 					var9.packetBuffer.writeInt(FriendSystem.selectedItemWidget);
-					var9.packetBuffer.method5613(class65.selectedItemSlot);
-					var9.packetBuffer.method5613(MusicPatch.selectedItemId);
+					var9.packetBuffer.writeIntME(class65.selectedItemSlot);
+					var9.packetBuffer.writeIntME(MusicPatch.selectedItemId);
 					Client.packetWriter.addNode(var9);
 				}
 			} else if (var2 == 8) {
@@ -212,7 +212,7 @@ public class UserComparator10 extends AbstractUserComparator {
 					Client.destinationX = var0;
 					Client.destinationY = var1;
 					var9 = TilePaint.getPacketBufferNode(ClientPacket.field2211, Client.packetWriter.isaacCipher);
-					var9.packetBuffer.method5613(var3);
+					var9.packetBuffer.writeIntME(var3);
 					var9.packetBuffer.method5604(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
 					Client.packetWriter.addNode(var9);
 				}
@@ -272,7 +272,7 @@ public class UserComparator10 extends AbstractUserComparator {
 						var9 = TilePaint.getPacketBufferNode(ClientPacket.field2290, Client.packetWriter.isaacCipher);
 						var9.packetBuffer.writeShort(MusicPatch.selectedItemId);
 						var9.packetBuffer.method5603(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
-						var9.packetBuffer.method5613(class65.selectedItemSlot);
+						var9.packetBuffer.writeIntME(class65.selectedItemSlot);
 						var9.packetBuffer.method5624(FriendSystem.selectedItemWidget);
 						var9.packetBuffer.method5787(var3);
 						Client.packetWriter.addNode(var9);
@@ -301,13 +301,13 @@ public class UserComparator10 extends AbstractUserComparator {
 					Client.destinationX = var0;
 					Client.destinationY = var1;
 					var8 = TilePaint.getPacketBufferNode(ClientPacket.field2272, Client.packetWriter.isaacCipher);
-					var8.packetBuffer.method5613(Language.baseY * 64 + var1);
-					var8.packetBuffer.method5613(Messages.baseX * 64 + var0);
+					var8.packetBuffer.writeIntME(Language.baseY * 64 + var1);
+					var8.packetBuffer.writeIntME(Messages.baseX * 64 + var0);
 					var8.packetBuffer.method5624(FriendSystem.selectedItemWidget);
 					var8.packetBuffer.writeShort(class65.selectedItemSlot);
-					var8.packetBuffer.method5613(MusicPatch.selectedItemId);
+					var8.packetBuffer.writeIntME(MusicPatch.selectedItemId);
 					var8.packetBuffer.method5604(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
-					var8.packetBuffer.method5613(var3);
+					var8.packetBuffer.writeIntME(var3);
 					Client.packetWriter.addNode(var8);
 				} else if (var2 == 17) {
 					Client.mouseCrossX = var6;
@@ -335,7 +335,7 @@ public class UserComparator10 extends AbstractUserComparator {
 					var8.packetBuffer.method5787(Messages.baseX * 64 + var0);
 					var8.packetBuffer.writeShort(var3);
 					var8.packetBuffer.method5603(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
-					var8.packetBuffer.writeIntME(Language.baseY * 64 + var1);
+					var8.packetBuffer.writeShortLE(Language.baseY * 64 + var1);
 					Client.packetWriter.addNode(var8);
 				} else if (var2 == 19) {
 					Client.mouseCrossX = var6;
@@ -345,10 +345,10 @@ public class UserComparator10 extends AbstractUserComparator {
 					Client.destinationX = var0;
 					Client.destinationY = var1;
 					var8 = TilePaint.getPacketBufferNode(ClientPacket.field2297, Client.packetWriter.isaacCipher);
-					var8.packetBuffer.writeIntME(Messages.baseX * 64 + var0);
+					var8.packetBuffer.writeShortLE(Messages.baseX * 64 + var0);
 					var8.packetBuffer.writeByte(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
 					var8.packetBuffer.method5787(var3);
-					var8.packetBuffer.writeIntME(Language.baseY * 64 + var1);
+					var8.packetBuffer.writeShortLE(Language.baseY * 64 + var1);
 					Client.packetWriter.addNode(var8);
 				} else if (var2 == 20) {
 					Client.mouseCrossX = var6;
@@ -358,10 +358,10 @@ public class UserComparator10 extends AbstractUserComparator {
 					Client.destinationX = var0;
 					Client.destinationY = var1;
 					var8 = TilePaint.getPacketBufferNode(ClientPacket.field2224, Client.packetWriter.isaacCipher);
-					var8.packetBuffer.writeIntME(Messages.baseX * 64 + var0);
+					var8.packetBuffer.writeShortLE(Messages.baseX * 64 + var0);
 					var8.packetBuffer.writeByte(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
 					var8.packetBuffer.method5787(var3);
-					var8.packetBuffer.writeIntME(Language.baseY * 64 + var1);
+					var8.packetBuffer.writeShortLE(Language.baseY * 64 + var1);
 					Client.packetWriter.addNode(var8);
 				} else if (var2 == 21) {
 					Client.mouseCrossX = var6;
@@ -371,10 +371,10 @@ public class UserComparator10 extends AbstractUserComparator {
 					Client.destinationX = var0;
 					Client.destinationY = var1;
 					var8 = TilePaint.getPacketBufferNode(ClientPacket.field2227, Client.packetWriter.isaacCipher);
-					var8.packetBuffer.writeIntME(Language.baseY * 64 + var1);
-					var8.packetBuffer.writeIntME(var3);
+					var8.packetBuffer.writeShortLE(Language.baseY * 64 + var1);
+					var8.packetBuffer.writeShortLE(var3);
 					var8.packetBuffer.method5602(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
-					var8.packetBuffer.method5613(Messages.baseX * 64 + var0);
+					var8.packetBuffer.writeIntME(Messages.baseX * 64 + var0);
 					Client.packetWriter.addNode(var8);
 				} else if (var2 == 22) {
 					Client.mouseCrossX = var6;
@@ -385,9 +385,9 @@ public class UserComparator10 extends AbstractUserComparator {
 					Client.destinationY = var1;
 					var8 = TilePaint.getPacketBufferNode(ClientPacket.field2301, Client.packetWriter.isaacCipher);
 					var8.packetBuffer.method5787(Messages.baseX * 64 + var0);
-					var8.packetBuffer.method5613(var3);
+					var8.packetBuffer.writeIntME(var3);
 					var8.packetBuffer.method5603(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
-					var8.packetBuffer.method5613(Language.baseY * 64 + var1);
+					var8.packetBuffer.writeIntME(Language.baseY * 64 + var1);
 					Client.packetWriter.addNode(var8);
 				} else if (var2 == 23) {
 					if (Client.isMenuOpen) {
@@ -471,7 +471,7 @@ public class UserComparator10 extends AbstractUserComparator {
 								var8.packetBuffer.method5787(class65.selectedItemSlot);
 								var8.packetBuffer.method5624(var1);
 								var8.packetBuffer.method5787(var0);
-								var8.packetBuffer.method5613(var3);
+								var8.packetBuffer.writeIntME(var3);
 								var8.packetBuffer.method5622(FriendSystem.selectedItemWidget);
 								Client.packetWriter.addNode(var8);
 								Client.field751 = 0;
@@ -479,9 +479,9 @@ public class UserComparator10 extends AbstractUserComparator {
 								Client.field752 = var0;
 							} else if (var2 == 32) {
 								var8 = TilePaint.getPacketBufferNode(ClientPacket.field2250, Client.packetWriter.isaacCipher);
-								var8.packetBuffer.writeIntME(var0);
+								var8.packetBuffer.writeShortLE(var0);
 								var8.packetBuffer.method5787(var3);
-								var8.packetBuffer.writeIntME(Client.selectedSpellChildIndex);
+								var8.packetBuffer.writeShortLE(Client.selectedSpellChildIndex);
 								var8.packetBuffer.method5622(var1);
 								var8.packetBuffer.method5622(FontName.selectedSpellWidget);
 								Client.packetWriter.addNode(var8);
@@ -490,9 +490,9 @@ public class UserComparator10 extends AbstractUserComparator {
 								Client.field752 = var0;
 							} else if (var2 == 33) {
 								var8 = TilePaint.getPacketBufferNode(ClientPacket.field2291, Client.packetWriter.isaacCipher);
-								var8.packetBuffer.method5613(var0);
+								var8.packetBuffer.writeIntME(var0);
 								var8.packetBuffer.writeInt(var1);
-								var8.packetBuffer.method5613(var3);
+								var8.packetBuffer.writeIntME(var3);
 								Client.packetWriter.addNode(var8);
 								Client.field751 = 0;
 								Skeleton.field1793 = Varps.getWidget(var1);
@@ -500,7 +500,7 @@ public class UserComparator10 extends AbstractUserComparator {
 							} else if (var2 == 34) {
 								var8 = TilePaint.getPacketBufferNode(ClientPacket.field2302, Client.packetWriter.isaacCipher);
 								var8.packetBuffer.method5787(var3);
-								var8.packetBuffer.method5613(var0);
+								var8.packetBuffer.writeIntME(var0);
 								var8.packetBuffer.method5622(var1);
 								Client.packetWriter.addNode(var8);
 								Client.field751 = 0;
@@ -509,7 +509,7 @@ public class UserComparator10 extends AbstractUserComparator {
 							} else if (var2 == 35) {
 								var8 = TilePaint.getPacketBufferNode(ClientPacket.field2259, Client.packetWriter.isaacCipher);
 								var8.packetBuffer.method5787(var0);
-								var8.packetBuffer.method5613(var3);
+								var8.packetBuffer.writeIntME(var3);
 								var8.packetBuffer.method5623(var1);
 								Client.packetWriter.addNode(var8);
 								Client.field751 = 0;
@@ -518,8 +518,8 @@ public class UserComparator10 extends AbstractUserComparator {
 							} else if (var2 == 36) {
 								var8 = TilePaint.getPacketBufferNode(ClientPacket.field2248, Client.packetWriter.isaacCipher);
 								var8.packetBuffer.method5622(var1);
-								var8.packetBuffer.writeIntME(var0);
-								var8.packetBuffer.writeIntME(var3);
+								var8.packetBuffer.writeShortLE(var0);
+								var8.packetBuffer.writeShortLE(var3);
 								Client.packetWriter.addNode(var8);
 								Client.field751 = 0;
 								Skeleton.field1793 = Varps.getWidget(var1);
@@ -527,7 +527,7 @@ public class UserComparator10 extends AbstractUserComparator {
 							} else if (var2 == 37) {
 								var8 = TilePaint.getPacketBufferNode(ClientPacket.field2226, Client.packetWriter.isaacCipher);
 								var8.packetBuffer.method5624(var1);
-								var8.packetBuffer.writeIntME(var3);
+								var8.packetBuffer.writeShortLE(var3);
 								var8.packetBuffer.method5787(var0);
 								Client.packetWriter.addNode(var8);
 								Client.field751 = 0;
@@ -552,8 +552,8 @@ public class UserComparator10 extends AbstractUserComparator {
 
 								if (var2 == 39) {
 									var8 = TilePaint.getPacketBufferNode(ClientPacket.field2253, Client.packetWriter.isaacCipher);
-									var8.packetBuffer.method5613(var3);
-									var8.packetBuffer.writeIntME(var0);
+									var8.packetBuffer.writeIntME(var3);
+									var8.packetBuffer.writeShortLE(var0);
 									var8.packetBuffer.method5622(var1);
 									Client.packetWriter.addNode(var8);
 									Client.field751 = 0;
@@ -562,8 +562,8 @@ public class UserComparator10 extends AbstractUserComparator {
 								} else if (var2 == 40) {
 									var8 = TilePaint.getPacketBufferNode(ClientPacket.field2268, Client.packetWriter.isaacCipher);
 									var8.packetBuffer.method5623(var1);
-									var8.packetBuffer.method5613(var3);
-									var8.packetBuffer.writeIntME(var0);
+									var8.packetBuffer.writeIntME(var3);
+									var8.packetBuffer.writeShortLE(var0);
 									Client.packetWriter.addNode(var8);
 									Client.field751 = 0;
 									Skeleton.field1793 = Varps.getWidget(var1);
@@ -579,7 +579,7 @@ public class UserComparator10 extends AbstractUserComparator {
 									Client.field752 = var0;
 								} else if (var2 == 42) {
 									var8 = TilePaint.getPacketBufferNode(ClientPacket.field2215, Client.packetWriter.isaacCipher);
-									var8.packetBuffer.writeIntME(var3);
+									var8.packetBuffer.writeShortLE(var3);
 									var8.packetBuffer.method5622(var1);
 									var8.packetBuffer.writeShort(var0);
 									Client.packetWriter.addNode(var8);
@@ -589,7 +589,7 @@ public class UserComparator10 extends AbstractUserComparator {
 								} else if (var2 == 43) {
 									var8 = TilePaint.getPacketBufferNode(ClientPacket.field2261, Client.packetWriter.isaacCipher);
 									var8.packetBuffer.method5787(var0);
-									var8.packetBuffer.writeIntME(var3);
+									var8.packetBuffer.writeShortLE(var3);
 									var8.packetBuffer.method5624(var1);
 									Client.packetWriter.addNode(var8);
 									Client.field751 = 0;
@@ -648,7 +648,7 @@ public class UserComparator10 extends AbstractUserComparator {
 										Client.destinationY = var1;
 										var9 = TilePaint.getPacketBufferNode(ClientPacket.field2216, Client.packetWriter.isaacCipher);
 										var9.packetBuffer.writeByte(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
-										var9.packetBuffer.writeIntME(var3);
+										var9.packetBuffer.writeShortLE(var3);
 										Client.packetWriter.addNode(var9);
 									}
 								} else if (var2 == 48) {
@@ -715,9 +715,9 @@ public class UserComparator10 extends AbstractUserComparator {
 												if (var16 != null) {
 													var9 = TilePaint.getPacketBufferNode(ClientPacket.field2264, Client.packetWriter.isaacCipher);
 													var9.packetBuffer.method5787(Client.field802);
-													var9.packetBuffer.writeIntME(var0);
+													var9.packetBuffer.writeShortLE(var0);
 													var9.packetBuffer.method5623(var1);
-													var9.packetBuffer.writeIntME(var16.itemId);
+													var9.packetBuffer.writeShortLE(var16.itemId);
 													var9.packetBuffer.method5623(FontName.selectedSpellWidget);
 													var9.packetBuffer.writeShort(Client.selectedSpellChildIndex);
 													Client.packetWriter.addNode(var9);
@@ -734,8 +734,8 @@ public class UserComparator10 extends AbstractUserComparator {
 												Client.destinationY = var1;
 												var8 = TilePaint.getPacketBufferNode(ClientPacket.field2292, Client.packetWriter.isaacCipher);
 												var8.packetBuffer.method5604(KeyHandler.KeyHandler_pressedKeys[82] ? 1 : 0);
-												var8.packetBuffer.writeIntME(Messages.baseX * 64 + var0);
-												var8.packetBuffer.method5613(var3);
+												var8.packetBuffer.writeShortLE(Messages.baseX * 64 + var0);
+												var8.packetBuffer.writeIntME(var3);
 												var8.packetBuffer.writeShort(Language.baseY * 64 + var1);
 												Client.packetWriter.addNode(var8);
 												break label982;
@@ -747,7 +747,7 @@ public class UserComparator10 extends AbstractUserComparator {
 												Client.mouseCrossColor = 2;
 												Client.mouseCrossState = 0;
 												var8 = TilePaint.getPacketBufferNode(ClientPacket.field2228, Client.packetWriter.isaacCipher);
-												var8.packetBuffer.writeIntME(var3);
+												var8.packetBuffer.writeShortLE(var3);
 												Client.packetWriter.addNode(var8);
 												break label982;
 											}
@@ -766,7 +766,7 @@ public class UserComparator10 extends AbstractUserComparator {
 
 													if (var17 != null) {
 														var12 = TilePaint.getPacketBufferNode(ClientPacket.field2258, Client.packetWriter.isaacCipher);
-														var12.packetBuffer.method5613(var17.id);
+														var12.packetBuffer.writeIntME(var17.id);
 														Client.packetWriter.addNode(var12);
 													}
 												}

--- a/runescape-client/src/main/java/WorldMapAreaData.java
+++ b/runescape-client/src/main/java/WorldMapAreaData.java
@@ -196,7 +196,7 @@ public class WorldMapAreaData extends WorldMapArea {
 	@Export("resumePauseWidget")
 	static void resumePauseWidget(int var0, int var1) {
 		PacketBufferNode var2 = TilePaint.getPacketBufferNode(ClientPacket.field2256, Client.packetWriter.isaacCipher);
-		var2.packetBuffer.writeIntME(var1);
+		var2.packetBuffer.writeShortLE(var1);
 		var2.packetBuffer.writeInt(var0);
 		Client.packetWriter.addNode(var2);
 	}

--- a/runescape-client/src/main/java/WorldMapData_0.java
+++ b/runescape-client/src/main/java/WorldMapData_0.java
@@ -107,7 +107,7 @@ public class WorldMapData_0 extends AbstractWorldMapData {
 	public static void method189(int var0, AbstractArchive var1, String var2, String var3, int var4, boolean var5) {
 		int var6 = var1.getGroupId(var2);
 		int var7 = var1.getFileId(var6, var3);
-		TaskHandler.method3554(var0, var1, var6, var7, var4, var5);
+		TaskHandler.playMusicTrack(var0, var1, var6, var7, var4, var5);
 	}
 
 	@ObfuscatedName("i")

--- a/runescape-client/src/main/java/WorldMapRegion.java
+++ b/runescape-client/src/main/java/WorldMapRegion.java
@@ -936,8 +936,7 @@ public class WorldMapRegion {
 		signature = "(Lbx;I)V",
 		garbageValue = "-1195764731"
 	)
-	@Export("updateActorSequence")
-	static final void updateActorSequence(Actor var0) {
+	static final void method565(Actor var0) {
 		var0.movementSequence = var0.readySequence;
 		if (var0.pathLength == 0) {
 			var0.field997 = 0;
@@ -1224,7 +1223,7 @@ public class WorldMapRegion {
 	public static void method563(int var0, int var1, int var2, boolean var3) {
 		PacketBufferNode var4 = TilePaint.getPacketBufferNode(ClientPacket.field2255, Client.packetWriter.isaacCipher);
 		var4.packetBuffer.writeInt(var3 ? Client.field727 : 0);
-		var4.packetBuffer.writeIntME(var0);
+		var4.packetBuffer.writeShortLE(var0);
 		var4.packetBuffer.writeShort(var1);
 		var4.packetBuffer.writeByte(var2);
 		Client.packetWriter.addNode(var4);

--- a/runescape-client/src/main/java/WorldMapSprite.java
+++ b/runescape-client/src/main/java/WorldMapSprite.java
@@ -66,7 +66,7 @@ public final class WorldMapSprite {
 			int var1 = Client.npcIndices[var0];
 			NPC var2 = Client.npcs[var1];
 			if (var2 != null) {
-				ScriptFrame.method1161(var2, var2.definition.size);
+				ScriptFrame.updateActorSequence(var2, var2.definition.size);
 			}
 		}
 

--- a/runescape-client/src/main/java/class162.java
+++ b/runescape-client/src/main/java/class162.java
@@ -23,8 +23,7 @@ public class class162 implements class161 {
 		signature = "(Lii;Ljava/lang/String;Ljava/lang/String;IZI)V",
 		garbageValue = "-1967656766"
 	)
-	@Export("playMusicTrack")
-	public static void playMusicTrack(AbstractArchive var0, String var1, String var2, int var3, boolean var4) {
+	public static void method3523(AbstractArchive var0, String var1, String var2, int var3, boolean var4) {
 		int var5 = var0.getGroupId(var1);
 		int var6 = var0.getFileId(var5, var2);
 		class197.field2414 = 1;


### PR DESCRIPTION
- Fix error on sound options change when using the music plugin
- Item overlays—such as teleport charges, inventory tags, rune pouch display—now follow their overlaid item when being dragged.