### PR TITLE
SanLite 1.11.3 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<checkstyle.skip>true</checkstyle.skip>
 
 		<rs.version>188</rs.version>
-		<sanlite.version>1.11.2</sanlite.version>
+		<sanlite.version>1.11.3</sanlite.version>
 	</properties>
 
 	<licenses>

--- a/runescape-client/src/main/java/FloorDecoration.java
+++ b/runescape-client/src/main/java/FloorDecoration.java
@@ -32,7 +32,7 @@ public final class FloorDecoration {
 	int x;
 	@ObfuscatedName("o")
 	@ObfuscatedGetter(
-		intValue = 168820736
+		intValue = -588436191
 	)
 	@Export("y")
 	int y;

--- a/runescape-client/src/main/java/ObjectSound.java
+++ b/runescape-client/src/main/java/ObjectSound.java
@@ -27,18 +27,18 @@ public final class ObjectSound extends Node {
 	int x;
 	@ObfuscatedName("e")
 	@ObfuscatedGetter(
-		intValue = 379220137
+		intValue = 1295537280
 	)
 	@Export("y")
 	int y;
 	@ObfuscatedName("i")
 	@ObfuscatedGetter(
-		intValue = -1169695104
+		intValue = 393514941
 	)
 	int field1069;
 	@ObfuscatedName("g")
 	@ObfuscatedGetter(
-		intValue = -711212539
+		intValue = -840891776
 	)
 	int field1080;
 	@ObfuscatedName("d")

--- a/runescape-client/src/main/java/WallDecoration.java
+++ b/runescape-client/src/main/java/WallDecoration.java
@@ -16,13 +16,13 @@ public final class WallDecoration {
 	int tileHeight;
 	@ObfuscatedName("t")
 	@ObfuscatedGetter(
-		intValue = -724566016
+		intValue = 915149021
 	)
 	@Export("x")
 	int x;
 	@ObfuscatedName("o")
 	@ObfuscatedGetter(
-		intValue = 357564416
+		intValue = 1541741189
 	)
 	@Export("y")
 	int y;


### PR DESCRIPTION
- Fix ground objects & floor decorations not working correctly. Affected plugins features should work properly again (eg. Theatre of Blood and Object Indicators)