### PR TITLE
alchemical-hydra: hybrid attack detection system & color opacity

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/AnimationID.java
+++ b/runelite-api/src/main/java/net/runelite/api/AnimationID.java
@@ -244,28 +244,23 @@ public final class AnimationID
 	// Pestilent Bloat
 	public static final int BLOAT_SLEEP = 8082;
 
-	// Hydra
-	public static final int HYDRA_POISON_1 = 8234;
-	public static final int HYDRA_RANGED_1 = 8235;
-	public static final int HYDRA_MAGIC_1 = 8236;
+	// Alchemical Hydra
+	public static final int ALCHEMICAL_HYDRA_GREEN_PHASE_POISON_ATTACK = 8234;
+	public static final int ALCHEMICAL_HYDRA_GREEN_PHASE_RANGED_ATTACK = 8235;
+	public static final int ALCHEMICAL_HYDRA_GREEN_PHASE_MAGIC_ATTACK = 8236;
 	public static final int ALCHEMICAL_HYDRA_SWITCH_TO_BLUE_PHASE = 8237;
-	public static final int HYDRA_1_2 = 8238;
-	public static final int HYDRA_LIGHTNING = 8241;
-	public static final int HYDRA_RANGED_2 = 8242;
-	public static final int HYDRA_MAGIC_2 = 8243;
+	public static final int ALCHEMICAL_HYDRA_BLUE_PHASE_LIGHTNING_ATTACK = 8241;
+	public static final int ALCHEMICAL_HYDRA_BLUE_PHASE_RANGED_ATTACK = 8242;
+	public static final int ALCHEMICAL_HYDRA_BLUE_PHASE_MAGIC_ATTACK = 8243;
 	public static final int ALCHEMICAL_HYDRA_SWITCH_TO_RED_PHASE = 8244;
-	public static final int HYDRA_2_2 = 8245;
-	public static final int HYDRA_FIRE = 8248;
-	public static final int HYDRA_RANGED_3 = 8249;
-	public static final int HYDRA_MAGIC_3 = 8250;
+	public static final int ALCHEMICAL_HYDRA_RED_PHASE_FIRE_ATTACK = 8248;
+	public static final int ALCHEMICAL_HYDRA_RED_PHASE_RANGED_ATTACK = 8249;
+	public static final int ALCHEMICAL_HYDRA_RED_PHASE_MAGIC_ATTACK = 8250;
 	public static final int ALCHEMICAL_HYDRA_SWITCH_TO_JAD_PHASE = 8251;
-	public static final int HYDRA_3_2 = 8252;
-	public static final int HYDRA_MAGIC_4 = 8254;
-	public static final int HYDRA_POISON_4 = 8254;
-	public static final int HYDRA_RANGED_4 = 8255;
-	public static final int ALCHEMICAL_HYDRA_JAD_PHASE_POISON_ATTACK = 8256;
-	public static final int HYDRA_4_1 = 8257;
-	public static final int HYDRA_4_2 = 8258;
+	public static final int ALCHEMICAL_HYDRA_JAD_PHASE_MAGIC_ATTACK = 8255;
+	public static final int ALCHEMICAL_HYDRA_JAD_PHASE_RANGED_ATTACK = 8256;
+	public static final int ALCHEMICAL_HYDRA_JAD_PHASE_POISON_ATTACK = 8255;
+	public static final int ALCHEMICAL_HYDRA_JAD_PHASE_POISON_ATTACK_2 = 8256;
 
 	// Inferno animations
 	public static final int JAL_NIB = 7574;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydra.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydra.java
@@ -265,12 +265,10 @@ class AlchemicalHydra
 	{
 		if (attackStyle == AttackStyle.MAGIC)
 		{
-			log.debug("Determined initial jad attack: {} | Next: {}", AttackStyle.RANGED, nextAttackTick);
 			return AttackStyle.RANGED;
 		}
 		else if (attackStyle == AttackStyle.RANGED)
 		{
-			log.debug("Determined initial jad attack: {} | Next: {}", AttackStyle.MAGIC, nextAttackTick);
 			return AttackStyle.MAGIC;
 		}
 		log.warn("Could not determine initial jad attack | Next: {}", nextAttackTick);
@@ -279,7 +277,6 @@ class AlchemicalHydra
 
 	void onAttack(int animationId, int tickCount, boolean fallbackAttack)
 	{
-		log.debug("Tick: {} | Regular attack: {} | Style: {} | Next: {}", tickCount, animationId, animationIdToAttackStyle(animationId), nextAttackTick);
 		lastAnimationId = animationId;
 		lastAttackTick = tickCount;
 		lastAttackStyle = animationIdToAttackStyle(animationId);
@@ -291,7 +288,6 @@ class AlchemicalHydra
 			{
 				// Redetermine the initial jad attack since the fallback attack occurred after the phase switch
 				currentAttackStyle = determineInitialJadPhaseAttackStyle(lastAttackStyle);
-				log.debug("Tick: {} | Recalculated initial jad attack: {} | Next: {}", tickCount, currentAttackStyle, nextAttackTick);
 				return;
 			}
 			updateAttackValues(tickCount + ENRAGED_ATTACK_RATE, attacksUntilSwitch - 3, attacksUntilSpecialAttack - 3, animationId);
@@ -327,7 +323,6 @@ class AlchemicalHydra
 			case AnimationID.ALCHEMICAL_HYDRA_BLUE_PHASE_LIGHTNING_ATTACK:
 			case AnimationID.ALCHEMICAL_HYDRA_JAD_PHASE_POISON_ATTACK:
 			case AnimationID.ALCHEMICAL_HYDRA_JAD_PHASE_POISON_ATTACK_2:
-				log.debug("Tick: {} | Poison/lightning attack: {} | Next: {}", tickCount, animationId, nextAttackTick);
 				// Jad phase has a faster attack rate
 				resetSpecialAttack(
 						currentPhase.equals(Phase.JAD) ? ATTACKS_PER_SPECIAL_ATTACK * 3 : ATTACKS_PER_SPECIAL_ATTACK,
@@ -339,14 +334,12 @@ class AlchemicalHydra
 				if (lastAnimationId != AnimationID.ALCHEMICAL_HYDRA_RED_PHASE_FIRE_ATTACK)
 				{
 					resetSpecialAttack(ATTACKS_PER_SPECIAL_ATTACK, tickCount + ATTACK_RATE, tickCount, animationId);
-					log.debug("Tick: {} | Initial fire attack: {} | Next: {}", tickCount, animationId, nextAttackTick);
 					return;
 				}
 
 				// Ignore second fire prison attack
 				if (tickCount - lastAttackTick < 5)
 				{
-					log.debug("Tick: {} | Ticks since last attack: {} | anim: {} | Next: {}", tickCount, tickCount - lastAttackTick, animationId, nextAttackTick);
 					return;
 				}
 
@@ -354,7 +347,6 @@ class AlchemicalHydra
 				lastAttackTick = tickCount;
 				nextAttackTick = tickCount + DELAY_AFTER_FIRE_SPECIAL_ATTACK;
 				lastAnimationId = animationId;
-				log.debug("Tick: {} | Second fire attack: {} | Next: {}", tickCount, animationId, nextAttackTick);
 				break;
 		}
 	}
@@ -385,7 +377,6 @@ class AlchemicalHydra
 		if (currentAttackStyle == null)
 		{
 			currentAttackStyle = attackStyle;
-			log.debug("Set current attack style: {} ", attackStyle);
 
 		}
 		// Correct attacks until switch value when de-sync might occur (eg. plugin enabled during kill)
@@ -401,12 +392,10 @@ class AlchemicalHydra
 		else if (attacksUntilSwitch <= 0 && currentAttackStyle == AttackStyle.MAGIC)
 		{
 			switchCurrentAttackStyle(AttackStyle.RANGED, ATTACKS_PER_SWITCH);
-			log.debug("Switched to attack style: {} ", AttackStyle.RANGED);
 		}
 		else if (attacksUntilSwitch <= 0)
 		{
 			switchCurrentAttackStyle(AttackStyle.MAGIC, ATTACKS_PER_SWITCH);
-			log.debug("Switched to attack style: {} ", AttackStyle.MAGIC);
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydra.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydra.java
@@ -107,14 +107,14 @@ class AlchemicalHydra
 
 	@Getter
 	@Setter
-	private int recentProjectileId;
+	private int lastAnimationId;
 
 	AlchemicalHydra(NPC npc)
 	{
 		this.npc = npc;
 		this.lastAttackTick = -100;
 		this.nextAttackTick = -100;
-		this.recentProjectileId = -1;
+		this.lastAnimationId = -1;
 		this.attacksUntilSwitch = ATTACKS_PER_SWITCH;
 		this.attacksUntilSpecialAttack = ATTACKS_PER_INITIAL_SPECIAL_ATTACK;
 		this.currentPhase = Phase.GREEN;
@@ -137,7 +137,7 @@ class AlchemicalHydra
 				projectileId == ProjectileID.ALCHEMICAL_HYDRA_FIRE;
 	}
 
-	boolean isSpecialAttack(int graphicsObjectId)
+	boolean isSpecialAttackGraphicsObject(int graphicsObjectId)
 	{
 		return graphicsObjectId == GraphicID.ALCHEMICAL_HYDRA_POISON_SPLAT_BEFORE_LANDING ||
 				graphicsObjectId == GraphicID.ALCHEMICAL_HYDRA_POISON_SPLAT_1 ||
@@ -152,6 +152,41 @@ class AlchemicalHydra
 				graphicsObjectId == GraphicID.ALCHEMICAL_HYDRA_LIGHTNING_ATTACK_2 ||
 				graphicsObjectId == GraphicID.ALCHEMICAL_HYDRA_FIRE_ATTACK;
 	}
+
+	boolean isAlchemicalHydraAnimation(int animationId)
+	{
+		return isSpecialAttackAnimation(animationId) || isRegularAttackAnimation(animationId) ||
+				isPhaseSwitchAnimation(animationId);
+	}
+
+	boolean isSpecialAttackAnimation(int animationId)
+	{
+		return animationId == AnimationID.ALCHEMICAL_HYDRA_GREEN_PHASE_POISON_ATTACK ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_BLUE_PHASE_LIGHTNING_ATTACK ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_RED_PHASE_FIRE_ATTACK ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_JAD_PHASE_POISON_ATTACK ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_JAD_PHASE_POISON_ATTACK_2;
+	}
+
+	boolean isRegularAttackAnimation(int animationId)
+	{
+		return animationId == AnimationID.ALCHEMICAL_HYDRA_GREEN_PHASE_MAGIC_ATTACK ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_GREEN_PHASE_RANGED_ATTACK ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_BLUE_PHASE_MAGIC_ATTACK ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_BLUE_PHASE_RANGED_ATTACK ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_RED_PHASE_MAGIC_ATTACK ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_RED_PHASE_RANGED_ATTACK ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_JAD_PHASE_MAGIC_ATTACK ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_JAD_PHASE_RANGED_ATTACK;
+	}
+
+	boolean isPhaseSwitchAnimation(int animationId)
+	{
+		return animationId == AnimationID.ALCHEMICAL_HYDRA_SWITCH_TO_BLUE_PHASE ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_SWITCH_TO_RED_PHASE ||
+				animationId == AnimationID.ALCHEMICAL_HYDRA_SWITCH_TO_JAD_PHASE;
+	}
+
 
 	boolean isPoisonSplatSpecialAttackBeforeLanding(int graphicsObjectId)
 	{
@@ -240,9 +275,10 @@ class AlchemicalHydra
 		currentSpecialAttackStyle = null;
 	}
 
-	void onAttack(int projectileId, int tickCount)
+	void onAttack(int animationId, int tickCount)
 	{
-		recentProjectileId = projectileId;
+		log.debug("Tick: {} | Regular attack: {} | Style: {} | Next: {}", tickCount, animationId, animationIdToAttackStyle(animationId), nextAttackTick);
+		lastAnimationId = animationId;
 		lastAttackTick = tickCount;
 
 		// Count ranged & magic attacks as three attacks during jad phase (attack style switches every other attack)
@@ -251,7 +287,7 @@ class AlchemicalHydra
 			nextAttackTick = tickCount + ENRAGED_ATTACK_RATE;
 			attacksUntilSwitch -= 3;
 			attacksUntilSpecialAttack -= 3;
-			checkAttackStyleSwitch(projectileIdToAttackStyle(projectileId));
+			checkAttackStyleSwitch(animationIdToAttackStyle(animationId));
 			return;
 		}
 
@@ -259,55 +295,61 @@ class AlchemicalHydra
 		nextAttackTick = tickCount + ATTACK_RATE;
 		attacksUntilSwitch--;
 		attacksUntilSpecialAttack--;
-		checkAttackStyleSwitch(projectileIdToAttackStyle(projectileId));
+		checkAttackStyleSwitch(animationIdToAttackStyle(animationId));
 	}
 
 	/**
 	 * Handles the Alchemical Hydra's special attack for the current phase.
 	 *
-	 * @param id        projectile/animation id
-	 * @param tickCount current game tick
+	 * @param animationId animation id
+	 * @param tickCount   current game tick
 	 */
-	void onSpecialAttack(int id, int tickCount)
+	void onSpecialAttack(int animationId, int tickCount)
 	{
-		// In rare occasions the poison special attack during jad phase will not spawn a projectile
-		// So we use the jad phase poison attack animation id instead to make sure the attack is detected
-		if (currentPhase == Phase.JAD && id == AnimationID.ALCHEMICAL_HYDRA_JAD_PHASE_POISON_ATTACK)
+		switch (animationId)
 		{
-			// Jad poison attack uses enraged attack rate
-			attacksUntilSpecialAttack = ATTACKS_PER_SPECIAL_ATTACK * 3;
-			nextAttackTick = tickCount + ENRAGED_ATTACK_RATE;
-			recentProjectileId = ProjectileID.ALCHEMICAL_HYDRA_POISON;
-			lastAttackTick = tickCount;
-			currentSpecialAttackStyle = null;
-			return;
-		}
-		else if (currentPhase == Phase.RED)
-		{
-			attacksUntilSpecialAttack = ATTACKS_PER_SPECIAL_ATTACK;
+			case AnimationID.ALCHEMICAL_HYDRA_GREEN_PHASE_POISON_ATTACK:
+			case AnimationID.ALCHEMICAL_HYDRA_BLUE_PHASE_LIGHTNING_ATTACK:
+			case AnimationID.ALCHEMICAL_HYDRA_JAD_PHASE_POISON_ATTACK:
+			case AnimationID.ALCHEMICAL_HYDRA_JAD_PHASE_POISON_ATTACK_2:
+				log.debug("Tick: {} | Poison/lightning attack: {} | Next: {}", tickCount, animationId, nextAttackTick);
+				// Jad phase has a faster attack rate
+				resetSpecialAttack(
+						currentPhase.equals(Phase.JAD) ? ATTACKS_PER_SPECIAL_ATTACK * 3 : ATTACKS_PER_SPECIAL_ATTACK,
+						currentPhase.equals(Phase.JAD) ? tickCount + ENRAGED_ATTACK_RATE : tickCount + ATTACK_RATE,
+						tickCount, animationId);
+				break;
+			case AnimationID.ALCHEMICAL_HYDRA_RED_PHASE_FIRE_ATTACK:
+				// Initial fire special to spawn the fire prison
+				if (lastAnimationId != AnimationID.ALCHEMICAL_HYDRA_RED_PHASE_FIRE_ATTACK)
+				{
+					resetSpecialAttack(ATTACKS_PER_SPECIAL_ATTACK, tickCount + ATTACK_RATE, tickCount, animationId);
+					log.debug("Tick: {} | Initial fire attack: {} | Next: {}", tickCount, animationId, nextAttackTick);
+					return;
+				}
 
-			// Initial fire special to spawn the fire prison
-			if (recentProjectileId != ProjectileID.ALCHEMICAL_HYDRA_FIRE)
-			{
-				recentProjectileId = id;
+				// Ignore second fire prison attack
+				if (tickCount - lastAttackTick < 5)
+				{
+					log.debug("Tick: {} | Ticks since last attack: {} | anim: {} | Next: {}", tickCount, tickCount - lastAttackTick, animationId, nextAttackTick);
+					return;
+				}
+
+				// Second fire special that follows the player
 				lastAttackTick = tickCount;
-				currentSpecialAttackStyle = null;
-				nextAttackTick = tickCount + ATTACK_RATE;
-				return;
-			}
-
-			// Second fire special that follows the player
-			nextAttackTick = tickCount + DELAY_AFTER_FIRE_SPECIAL_ATTACK;
+				nextAttackTick = tickCount + DELAY_AFTER_FIRE_SPECIAL_ATTACK;
+				lastAnimationId = animationId;
+				log.debug("Tick: {} | Second fire attack: {} | Next: {}", tickCount, animationId, nextAttackTick);
+				break;
 		}
-		else
-		{
-			// Poison & lightning special use regular attack rate
-			attacksUntilSpecialAttack = ATTACKS_PER_SPECIAL_ATTACK;
-			nextAttackTick = tickCount + ATTACK_RATE;
-		}
+	}
 
-		recentProjectileId = id;
+	void resetSpecialAttack(int attacksTillSpecial, int nextAttackTick, int tickCount, int animationId)
+	{
+		attacksUntilSpecialAttack = attacksTillSpecial;
+		this.nextAttackTick = nextAttackTick;
 		lastAttackTick = tickCount;
+		lastAnimationId = animationId;
 		currentSpecialAttackStyle = null;
 	}
 
@@ -328,20 +370,28 @@ class AlchemicalHydra
 		if (currentAttackStyle == null)
 		{
 			currentAttackStyle = attackStyle;
+			log.debug("Set current attack style: {} ", attackStyle);
+
+		}
+		// Correct attacks until switch value when de-sync might occur (eg. plugin enabled during kill)
+		else if (currentAttackStyle != attackStyle)
+		{
+			int attacksPerSwitch = currentPhase.equals(Phase.JAD) ? ATTACKS_PER_SWITCH - 3 : ATTACKS_PER_SWITCH - 1;
+			AttackStyle newJadPhaseAttackStyle = attackStyle.equals(AttackStyle.MAGIC) ? AttackStyle.RANGED : AttackStyle.MAGIC;
+
+			switchCurrentAttackStyle(currentPhase.equals(Phase.JAD) ? newJadPhaseAttackStyle : attackStyle, attacksPerSwitch);
+			log.warn("De-sync switch to: {} | Attacks left: {}", currentPhase.equals(Phase.JAD) ?
+					newJadPhaseAttackStyle : attackStyle, attacksUntilSwitch);
 		}
 		else if (attacksUntilSwitch <= 0 && currentAttackStyle == AttackStyle.MAGIC)
 		{
 			switchCurrentAttackStyle(AttackStyle.RANGED, ATTACKS_PER_SWITCH);
+			log.debug("Switched to attack style: {} ", AttackStyle.RANGED);
 		}
-		else if (attacksUntilSwitch <= 0 && currentAttackStyle == AttackStyle.RANGED)
+		else if (attacksUntilSwitch <= 0)
 		{
 			switchCurrentAttackStyle(AttackStyle.MAGIC, ATTACKS_PER_SWITCH);
-		}
-		// Correct attacks until switch value when de-sync might occur (eg. plugin enabled during kill)
-		else if (attacksUntilSwitch > 0 && currentAttackStyle != attackStyle)
-		{
-			log.warn("De-sync switch to: {} | Attacks left: {}", attackStyle, attacksUntilSwitch);
-			switchCurrentAttackStyle(attackStyle, ATTACKS_PER_SWITCH - 1);
+			log.debug("Switched to attack style: {} ", AttackStyle.MAGIC);
 		}
 	}
 
@@ -375,12 +425,13 @@ class AlchemicalHydra
 	}
 
 	/**
-	 * Checks for phase switches through animation id's. If this is the jad phase it will change
-	 * the next attack style when necessary.
+	 * Checks what the next phase is for the given animation id
+	 *
+	 * @param animationId phase switch animation id
+	 * @param tickCount   current game tick
 	 */
-	void checkAlchemicalHydraPhaseSwitch(int tickCount)
+	void checkAlchemicalHydraPhaseSwitch(int animationId, int tickCount)
 	{
-		int animationId = npc.getAnimation();
 		if (animationId == AnimationID.ALCHEMICAL_HYDRA_SWITCH_TO_BLUE_PHASE && currentPhase != Phase.BLUE)
 		{
 			switchPhase(Phase.BLUE, tickCount);
@@ -401,32 +452,51 @@ class AlchemicalHydra
 	void checkGraphicObjects(List<GraphicsObject> graphicsObjects)
 	{
 		aoeEffects = graphicsObjects.stream()
-				.filter(x -> isSpecialAttack(x.getId()))
+				.filter(x -> isSpecialAttackGraphicsObject(x.getId()))
 				.collect(Collectors.toList());
 	}
 
 	/**
-	 * Get an Alchemical Hydra attack style based on the given projectile id.
+	 * Get an Alchemical Hydra attack style based on the given animationId id.
 	 *
-	 * @param projectileId alchemical hydra projectile id
+	 * @param animationId alchemical hydra animation id
 	 * @return Alchemical Hydra attack style
 	 */
-	private AttackStyle projectileIdToAttackStyle(int projectileId)
+	private AttackStyle animationIdToAttackStyle(int animationId)
+	{
+		switch (animationId)
+		{
+			case AnimationID.ALCHEMICAL_HYDRA_GREEN_PHASE_RANGED_ATTACK:
+			case AnimationID.ALCHEMICAL_HYDRA_BLUE_PHASE_RANGED_ATTACK:
+			case AnimationID.ALCHEMICAL_HYDRA_RED_PHASE_RANGED_ATTACK:
+			case AnimationID.ALCHEMICAL_HYDRA_JAD_PHASE_RANGED_ATTACK:
+				return AttackStyle.RANGED;
+			case AnimationID.ALCHEMICAL_HYDRA_GREEN_PHASE_MAGIC_ATTACK:
+			case AnimationID.ALCHEMICAL_HYDRA_BLUE_PHASE_MAGIC_ATTACK:
+			case AnimationID.ALCHEMICAL_HYDRA_RED_PHASE_MAGIC_ATTACK:
+			case AnimationID.ALCHEMICAL_HYDRA_JAD_PHASE_MAGIC_ATTACK:
+				return AttackStyle.MAGIC;
+			default:
+				return null;
+		}
+	}
+
+	int projectileIdToAnimationId(int projectileId)
 	{
 		switch (projectileId)
 		{
-			case ProjectileID.ALCHEMICAL_HYDRA_RANGED:
-				return AttackStyle.RANGED;
 			case ProjectileID.ALCHEMICAL_HYDRA_MAGIC:
-				return AttackStyle.MAGIC;
+				return AnimationID.ALCHEMICAL_HYDRA_GREEN_PHASE_MAGIC_ATTACK;
+			case ProjectileID.ALCHEMICAL_HYDRA_RANGED:
+				return AnimationID.ALCHEMICAL_HYDRA_GREEN_PHASE_RANGED_ATTACK;
 			case ProjectileID.ALCHEMICAL_HYDRA_POISON:
-				return AttackStyle.POISON;
+				return AnimationID.ALCHEMICAL_HYDRA_GREEN_PHASE_POISON_ATTACK;
 			case ProjectileID.ALCHEMICAL_HYDRA_LIGHTNING:
-				return AttackStyle.LIGHTNING;
+				return AnimationID.ALCHEMICAL_HYDRA_BLUE_PHASE_LIGHTNING_ATTACK;
 			case ProjectileID.ALCHEMICAL_HYDRA_FIRE:
-				return AttackStyle.FIRE;
+				return AnimationID.ALCHEMICAL_HYDRA_RED_PHASE_FIRE_ATTACK;
 			default:
-				return null;
+				return -1;
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraConfig.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.client.plugins.alchemicalhydra;
 
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -55,6 +56,7 @@ public interface AlchemicalHydraConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 			keyName = "attackTimerTextColor",
 			name = "Attack timer text color",
@@ -78,6 +80,7 @@ public interface AlchemicalHydraConfig extends Config
 		return true;
 	}
 
+	@Alpha
 	@ConfigItem(
 			keyName = "poisonAttackColor",
 			name = "Poison attack marker",
@@ -90,6 +93,7 @@ public interface AlchemicalHydraConfig extends Config
 		return new Color(159, 219, 0);
 	}
 
+	@Alpha
 	@ConfigItem(
 			keyName = "lightningAttackColor",
 			name = "Lightning marker",
@@ -102,6 +106,7 @@ public interface AlchemicalHydraConfig extends Config
 		return new Color(3, 133, 219);
 	}
 
+	@Alpha
 	@ConfigItem(
 			keyName = "fireAttackColor",
 			name = "Fire marker",
@@ -114,6 +119,7 @@ public interface AlchemicalHydraConfig extends Config
 		return new Color(219, 116, 0, 255);
 	}
 
+	@Alpha
 	@ConfigItem(
 			keyName = "notOnChemicalPoolColor",
 			name = "Not on fountain marker",
@@ -126,6 +132,7 @@ public interface AlchemicalHydraConfig extends Config
 		return new Color(Color.RED.getRGB());
 	}
 
+	@Alpha
 	@ConfigItem(
 			keyName = "onChemicalPoolColor",
 			name = "On fountain marker",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraDebugOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraDebugOverlay.java
@@ -107,8 +107,8 @@ public class AlchemicalHydraDebugOverlay extends Overlay
 					.build());
 
 			panelComponent.getChildren().add(LineComponent.builder()
-					.left("Recent projectile id")
-					.right("" + alchemicalHydra.getRecentProjectileId())
+					.left("Last animation id")
+					.right("" + alchemicalHydra.getLastAnimationId())
 					.build());
 
 			panelComponent.getChildren().add(LineComponent.builder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraDebugOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraDebugOverlay.java
@@ -77,6 +77,11 @@ public class AlchemicalHydraDebugOverlay extends Overlay
 					.build());
 
 			panelComponent.getChildren().add(LineComponent.builder()
+					.left("Last attack style")
+					.right("" + alchemicalHydra.getLastAttackStyle())
+					.build());
+
+			panelComponent.getChildren().add(LineComponent.builder()
 					.left("Current special attack style")
 					.right("" + alchemicalHydra.getCurrentSpecialAttackStyle())
 					.build());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraPlugin.java
@@ -215,8 +215,7 @@ public class AlchemicalHydraPlugin extends Plugin
 			int projectileId = projectile.getId();
 
 			// During the Jad phase animations can only be overridden by the death animation
-			if (!AlchemicalHydra.isAlchemicalHydraRegularAttackProjectile(projectileId) ||
-					alchemicalHydra.getCurrentPhase().equals(AlchemicalHydra.Phase.JAD))
+			if (!AlchemicalHydra.isAlchemicalHydraRegularAttackProjectile(projectileId))
 			{
 				return;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/AlchemicalHydraPlugin.java
@@ -26,7 +26,6 @@ package net.runelite.client.plugins.alchemicalhydra;
 
 import com.google.inject.Provides;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.events.*;
 import net.runelite.client.callback.ClientThread;
@@ -47,7 +46,6 @@ import java.util.Arrays;
 		tags = {"combat", "overlay", "pve", "pvm", "hydra", "alchemical", "boss", "slayer", "timer"},
 		type = PluginType.SANLITE_USE_AT_OWN_RISK
 )
-@Slf4j
 public class AlchemicalHydraPlugin extends Plugin
 {
 
@@ -214,7 +212,6 @@ public class AlchemicalHydraPlugin extends Plugin
 			Projectile projectile = event.getProjectile();
 			int projectileId = projectile.getId();
 
-			// During the Jad phase animations can only be overridden by the death animation
 			if (!AlchemicalHydra.isAlchemicalHydraRegularAttackProjectile(projectileId))
 			{
 				return;
@@ -226,13 +223,11 @@ public class AlchemicalHydraPlugin extends Plugin
 				return;
 			}
 
-			log.debug("Tick: {} | Attack passed first checks: {}", client.getTickCount(), projectileId);
 			int ticksSinceLastAttack = client.getTickCount() - alchemicalHydra.getLastAttackTick();
 			int attackRate = alchemicalHydra.getCurrentPhase() == AlchemicalHydra.Phase.JAD ?
 					AlchemicalHydra.ENRAGED_ATTACK_RATE : AlchemicalHydra.ATTACK_RATE;
 			if (ticksSinceLastAttack >= attackRate || alchemicalHydra.getLastAttackTick() == -100)
 			{
-				log.debug("Tick: {} | Fallback regular attack: {} | Next: {}", client.getTickCount(), projectileId, alchemicalHydra.getNextAttackTick());
 				alchemicalHydra.onAttack(alchemicalHydra.projectileIdToAnimationId(projectileId), client.getTickCount(), true);
 			}
 		}


### PR DESCRIPTION
- The Alchemical Hydra plugin is now way less likely to miss attacks.
- You can now change the color opacity in the Alchemical Hydra config.
- The Alchemical Hydra plugin will once again correct the attack counter when the last attack was wrong.