### PR TITLE
feat(menu-entry-swapper): adds swap for eat -> use on papaya fruit

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -777,6 +777,17 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "swapPapaya",
+			name = "Papaya",
+			description = "Swap Eat with Use on a Papaya",
+			section = itemSection
+	)
+	default boolean swapPapaya()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "swapRowboatDive",
 		name = "Fossil Island Rowboat Dive",
 		description = "Swap Travel with Dive on the rowboat found on the small island north-east of Fossil Island",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -777,10 +777,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "swapPapaya",
-			name = "Papaya",
-			description = "Swap Eat with Use on a Papaya",
-			section = itemSection
+	keyName = "swapPapaya",
+	name = "Papaya",
+	description = "Swap Eat with Use on a Papaya",
+	section = itemSection
+
 	)
 	default boolean swapPapaya()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -422,7 +422,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 		swap("eat", "guzzle", config::swapRockCake);
 
 		swap("eat", "papaya fruit", "use", config::swapPapaya);
-		//swap("eat", "use", config::swapPapaya);
 
 		swap("travel", "dive", config::swapRowboatDive);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -421,6 +421,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		swap("eat", "guzzle", config::swapRockCake);
 
+		swap("eat", "use", config::swapPapaya);
+
 		swap("travel", "dive", config::swapRowboatDive);
 
 		swap("climb", "climb-up", () -> (shiftModifier() ? config.swapStairsShiftClick() : config.swapStairsLeftClick()) == MenuEntrySwapperConfig.StairsMode.CLIMB_UP);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -421,7 +421,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		swap("eat", "guzzle", config::swapRockCake);
 
-		swap("eat", "use", config::swapPapaya);
+		swap("eat", "papaya fruit", "use", config::swapPapaya);
+		//swap("eat", "use", config::swapPapaya);
 
 		swap("travel", "dive", config::swapRowboatDive);
 


### PR DESCRIPTION
Added option to swap "eat" and "use" on a papaya fruit